### PR TITLE
Terraform config for launching AWS instance with security groups for HTTP, HTTPS, and SSH

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,2 @@
+terraform.tfvars
+.terraform*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,1 @@
+# instance_launch_and_configuration

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,0 +1,10 @@
+resource "aws_instance" "web" {
+  ami           = "ami-0cca134ec43cf708f"
+  instance_type = var.instance_type
+  count         = 1
+  key_name      = var.key
+   vpc_security_group_ids = [aws_security_group.TF_SG.id]
+  tags = {
+    Name = "AmazonLinux"
+  }
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "4.51.0"
+    }
+  }
+}
+provider "aws" {
+  region = var.region
+  access_key = var.access_key
+  secret_key = var.secret_key
+}
+
+

--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -1,0 +1,46 @@
+# security groups using terraform
+
+resource "aws_security_group" "TF_SG" {
+  name        = "TF_SG"
+  description = "Allow HTTP,HTTPS,SSH Access From Anywhere"
+  vpc_id      = var.default_vpc
+
+  ingress {
+    description      = "HTTPS Rule"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+    ingress {
+    description      = "HTTP Rule "
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+    ingress {
+    description      = "SSH Rule"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name = "HTTP_SSH_HTTPS_Group"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "region" {
+    type = string
+}
+
+variable "access_key" {
+    type = string
+}
+
+variable "secret_key" {
+    type = string
+}
+
+variable "instance_type" {
+    type = string
+}
+
+variable "key" {
+    type = string
+}
+
+variable "default_vpc" {
+    type = string
+}


### PR DESCRIPTION
Created Terraform configuration for launching an AWS instance with security groups configured for HTTP, HTTPS, and SSH access.